### PR TITLE
[MNM-56]style: chips className 추가

### DIFF
--- a/src/app/(home)/components/Card.tsx
+++ b/src/app/(home)/components/Card.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
+import Chip from "@/components/Chips";
 import Progressbar from "@/components/Progressbar";
-import Chip from "@/components/chip";
 
 export default function Card() {
   return (

--- a/src/app/(testPages)/date/page.tsx
+++ b/src/app/(testPages)/date/page.tsx
@@ -1,4 +1,5 @@
-import Chip from "@/components/chip";
+import Button from "@/components/Button/Button";
+import Chip from "@/components/Chips";
 import { formatToKoreanTime } from "@/utils/date";
 
 export default function page() {
@@ -31,6 +32,9 @@ export default function page() {
         <Chip type="time" fontSize="text-lg" fontWeight="font-bold">
           칠칠드런드런
         </Chip>
+        <Button color="yellow" className="cursor-pointer">
+          버튼
+        </Button>
       </div>
     </div>
   );

--- a/src/components/Chips.tsx
+++ b/src/components/Chips.tsx
@@ -7,6 +7,7 @@ export default function Chip({
   shadow = false,
   fontSize = "text-sm", // 기본 폰트 사이즈
   fontWeight = "font-medium", // 기본 폰트 굵기
+  className,
   children,
 }: ChipProps) {
   // 기본 스타일
@@ -25,7 +26,7 @@ export default function Chip({
 
   return (
     <div
-      className={`${baseClass} ${roundedClass} ${bgColor} ${textColor} ${shadowClass} ${fontSize} ${fontWeight}`}
+      className={`${baseClass} ${roundedClass} ${bgColor} ${textColor} ${shadowClass} ${fontSize} ${fontWeight} ${className}`}
     >
       {children}
     </div>

--- a/src/types/components/chip.d.ts
+++ b/src/types/components/chip.d.ts
@@ -7,5 +7,6 @@ export interface ChipProps {
   shadow?: boolean; // 그림자 여부
   fontSize?: string;
   fontWeight?: string; // 기본 폰트 굵기
+  className?: string;
   children: React.ReactNode; // 칩 내용
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

[MNM-56]

## 📝작업 내용

Chip 사용하실 때 className 넣으실 수 있도록 설정했습니다.
깃허브가 대소문자 구분 못해서 Chips로 바꿨어요

![스크린샷 2024-12-03 오전 10 34 52](https://github.com/user-attachments/assets/5538f9ac-88e4-446f-bb15-232a113db4e1)


```
<Chip type="default" className="w-[200px]">
          칩 예시
        </Chip>
```
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


[MNM-56]: https://daremfit.atlassian.net/browse/MNM-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ