### PR TITLE
[MNM-146]refactor: 메인페이지,로그인

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1648,6 +1648,126 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.18.tgz",
+      "integrity": "sha512-uJCEjutt5VeJ30jjrHV1VIHCsbMYnEqytQgvREx+DjURd/fmKy15NaVK4aR/u98S1LGTnjq35lRTnRyygglxoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.18.tgz",
+      "integrity": "sha512-IL6rU8vnBB+BAm6YSWZewc+qvdL1EaA+VhLQ6tlUc0xp+kkdxQrVqAnh8Zek1ccKHlTDFRyAft0e60gteYmQ4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.18.tgz",
+      "integrity": "sha512-RCaENbIZqKKqTlL8KNd+AZV/yAdCsovblOpYFp0OJ7ZxgLNbV5w23CUU1G5On+0fgafrsGcW+GdMKdFjaRwyYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.18.tgz",
+      "integrity": "sha512-3kmv8DlyhPRCEBM1Vavn8NjyXtMeQ49ID0Olr/Sut7pgzaQTo4h01S7Z8YNE0VtbowyuAL26ibcz0ka6xCTH5g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.18.tgz",
+      "integrity": "sha512-mliTfa8seVSpTbVEcKEXGjC18+TDII8ykW4a36au97spm9XMPqQTpdGPNBJ9RySSFw9/hLuaCMByluQIAnkzlw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.18.tgz",
+      "integrity": "sha512-J5g0UFPbAjKYmqS3Cy7l2fetFmWMY9Oao32eUsBPYohts26BdrMUyfCJnZFQkX9npYaHNDOWqZ6uV9hSDPw9NA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.18.tgz",
+      "integrity": "sha512-Ynxuk4ZgIpdcN7d16ivJdjsDG1+3hTvK24Pp8DiDmIa2+A4CfhJSEHHVndCHok6rnLUzAZD+/UOKESQgTsAZGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.18.tgz",
+      "integrity": "sha512-dtRGMhiU9TN5nyhwzce+7c/4CCeykYS+ipY/4mIrGzJ71+7zNo55ZxCB7cAVuNqdwtYniFNR2c9OFQ6UdFIMcg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -11226,126 +11346,6 @@
         "use-sync-external-store": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.18.tgz",
-      "integrity": "sha512-uJCEjutt5VeJ30jjrHV1VIHCsbMYnEqytQgvREx+DjURd/fmKy15NaVK4aR/u98S1LGTnjq35lRTnRyygglxoA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.18.tgz",
-      "integrity": "sha512-IL6rU8vnBB+BAm6YSWZewc+qvdL1EaA+VhLQ6tlUc0xp+kkdxQrVqAnh8Zek1ccKHlTDFRyAft0e60gteYmQ4A==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.18.tgz",
-      "integrity": "sha512-RCaENbIZqKKqTlL8KNd+AZV/yAdCsovblOpYFp0OJ7ZxgLNbV5w23CUU1G5On+0fgafrsGcW+GdMKdFjaRwyYA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.18.tgz",
-      "integrity": "sha512-3kmv8DlyhPRCEBM1Vavn8NjyXtMeQ49ID0Olr/Sut7pgzaQTo4h01S7Z8YNE0VtbowyuAL26ibcz0ka6xCTH5g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.18.tgz",
-      "integrity": "sha512-mliTfa8seVSpTbVEcKEXGjC18+TDII8ykW4a36au97spm9XMPqQTpdGPNBJ9RySSFw9/hLuaCMByluQIAnkzlw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.18.tgz",
-      "integrity": "sha512-J5g0UFPbAjKYmqS3Cy7l2fetFmWMY9Oao32eUsBPYohts26BdrMUyfCJnZFQkX9npYaHNDOWqZ6uV9hSDPw9NA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.18.tgz",
-      "integrity": "sha512-Ynxuk4ZgIpdcN7d16ivJdjsDG1+3hTvK24Pp8DiDmIa2+A4CfhJSEHHVndCHok6rnLUzAZD+/UOKESQgTsAZGg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.18.tgz",
-      "integrity": "sha512-dtRGMhiU9TN5nyhwzce+7c/4CCeykYS+ipY/4mIrGzJ71+7zNo55ZxCB7cAVuNqdwtYniFNR2c9OFQ6UdFIMcg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/src/apis/assignGatheringApi.ts
+++ b/src/apis/assignGatheringApi.ts
@@ -39,6 +39,11 @@ export async function createGathering(body: CreateGathering, image?: File) {
     },
     body: formData,
   });
+  if (!response.ok) {
+    // HTTP 상태 코드가 200-299가 아닌 경우 에러 throw
+    const errorData = await response.json();
+    throw new Error(errorData.message || "모임 생성에 실패했습니다.");
+  }
   const data: GatheringRes = await response.json();
   return data;
 }
@@ -48,8 +53,12 @@ export async function joinGathering(id: number) {
   const response = await fetchWithMiddleware(`/api/gatherings/${id}/join`, {
     method: "POST",
   });
+  if (!response.ok) {
+    // HTTP 상태 코드가 200-299가 아닌 경우 에러 throw
+    const errorData = await response.json();
+    throw new Error(errorData.message || "모임 참여에 실패했습니다.");
+  }
   const data = await response.json();
-  alert(data.message);
   return data;
 }
 

--- a/src/apis/favoriteGatheringApi.ts
+++ b/src/apis/favoriteGatheringApi.ts
@@ -8,7 +8,6 @@ export async function getFavoriteGathering(id: number) {
     method: "POST",
   });
   const data = await response.json();
-  alert(data.message);
   return data;
 }
 
@@ -18,7 +17,6 @@ export async function deleteFavoriteGathering(id: number) {
     method: "DELETE",
   });
   const data = await response.json();
-  alert(data.message);
   return data;
 }
 

--- a/src/apis/fetchWithMiddleware.ts
+++ b/src/apis/fetchWithMiddleware.ts
@@ -15,8 +15,8 @@ export default async function fetchWithMiddleware(url: string, options: RequestI
     });
 
     if (!refreshResponse.ok) {
-      // refresh 실패시 로그인 페이지로
-      window.location.href = "/";
+      // refresh 실패시 로그인 페이지로 이동,리다이렉트 페이지 기억
+      window.location.href = `/signin?redirect=${encodeURIComponent(window.location.pathname)}`;
       throw new Error("Token refresh failed");
     }
 

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -32,7 +32,9 @@ function LoginPage() {
     const response = await signin(data);
 
     if (response.ok) {
-      router.push("/");
+      const redirectTo = new URLSearchParams(window.location.search).get("redirect") || "/";
+      router.push(redirectTo);
+      router.refresh();
     } else {
       setIsPopupOpen("login-failed");
     }

--- a/src/app/(home)/_components/ButtonJoin.tsx
+++ b/src/app/(home)/_components/ButtonJoin.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { joinGathering } from "@/apis/assignGatheringApi";
+import useToastStore from "@/store/useToastStore";
 import useUserStore from "@/store/userStore";
 
 export default function ButtonJoin({
@@ -15,30 +16,22 @@ export default function ButtonJoin({
   onUpdate: () => void;
 }) {
   const [isParticipation, setIsParticipation] = useState(participation);
-  const [, setToast] = useState(false);
+  const addToast = useToastStore(state => state.addToast);
+
   const { id: userId } = useUserStore(); // 로그인 상태 확인
   const router = useRouter();
 
   async function handleJoinGathering() {
     try {
-      if (!userId) {
-        router.push("/signin");
-        return;
-      }
-      joinGathering(id);
+      const response = await joinGathering(id);
       setIsParticipation(true);
       onUpdate();
-      setToast(true);
+      addToast({ message: response.message, type: "success" });
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "알 수 없는 에러가 발생했습니다.";
-
-      if (errorMessage === "이미 참여한 모임입니다.") {
-        alert("이미 참여가 된 모임입니다.");
-      } else {
-        alert(errorMessage || "참여에 실패했습니다. 다시 시도해주세요.");
-      }
       console.error("참여 실패:", errorMessage);
+      addToast({ message: errorMessage, type: "error" });
     }
   }
 

--- a/src/app/(home)/_components/CreateGathering.tsx
+++ b/src/app/(home)/_components/CreateGathering.tsx
@@ -9,6 +9,7 @@ import Calendar from "@/components/Calendar/Calendar";
 import Kakao from "@/components/Kakaomap/Kakao";
 import Modal from "@/components/Modal";
 import useDateStore from "@/store/dateStore";
+import useToastStore from "@/store/useToastStore";
 import { CreateGatheringSchema } from "@/utils/createGathSchema";
 import {
   CreateGatheringFormData,
@@ -33,6 +34,7 @@ export default function CreateGathering({
   const [keywordValue, setKeywordValue] = useState("");
   const { firstDate } = useDateStore();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const addToast = useToastStore(state => state.addToast);
 
   const {
     register,
@@ -69,7 +71,7 @@ export default function CreateGathering({
   return (
     <Modal title="모임 만들기" isOpen={isOpen} onClose={() => setIsOpen(false)}>
       <form
-        onSubmit={handleSubmit(data => handleSubmitToServer(data, setIsOpen))}
+        onSubmit={handleSubmit(data => handleSubmitToServer(data, setIsOpen, addToast))}
         className="flex flex-col gap-4 overflow-y-scroll pb-6 font-medium"
       >
         {/* 모임 이름 */}

--- a/src/app/(home)/_components/CreateGathering.tsx
+++ b/src/app/(home)/_components/CreateGathering.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import Button from "@/components/Button/Button";
@@ -35,6 +36,7 @@ export default function CreateGathering({
   const { firstDate } = useDateStore();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const addToast = useToastStore(state => state.addToast);
+  const router = useRouter();
 
   const {
     register,
@@ -71,7 +73,7 @@ export default function CreateGathering({
   return (
     <Modal title="모임 만들기" isOpen={isOpen} onClose={() => setIsOpen(false)}>
       <form
-        onSubmit={handleSubmit(data => handleSubmitToServer(data, setIsOpen, addToast))}
+        onSubmit={handleSubmit(data => handleSubmitToServer(data, setIsOpen, addToast, router))}
         className="flex flex-col gap-4 overflow-y-scroll pb-6 font-medium"
       >
         {/* 모임 이름 */}

--- a/src/app/(home)/_components/Skeleton/SKCardList.tsx
+++ b/src/app/(home)/_components/Skeleton/SKCardList.tsx
@@ -1,0 +1,49 @@
+export default function SKCardList() {
+  return (
+    <div className="flex flex-col gap-4">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <div
+          key={index}
+          className="border-gray hover:scale-102 flex w-full transform animate-pulse flex-col rounded-2xl border-y-2 bg-gray-background transition-transform duration-200 tablet:h-[156px] tablet:w-full tablet:flex-row"
+        >
+          {/* 이미지 스켈레톤 */}
+          <div className="relative flex rounded-l-2xl bg-gray-200 tablet:h-[153px] tablet:w-[272px]">
+            <div className="absolute right-0 top-0 flex h-[20px] w-[100px] flex-row items-center gap-1 rounded-bl-xl border border-none bg-gray-300 px-2 py-1"></div>
+          </div>
+          {/* 텍스트 & 기타 요소 스켈레톤 */}
+          <div className="flex w-full flex-col justify-between p-4">
+            {/* 제목 및 주소 */}
+            <div className="flex justify-between">
+              <div className="flex w-4/5 flex-col gap-2">
+                <div className="flex flex-row items-center gap-2">
+                  <div className="h-5 w-3/4 rounded-md bg-gray-300"></div>
+                </div>
+                <div className="flex flex-row gap-2">
+                  <div className="h-5 w-1/4 rounded-md bg-gray-300"></div>
+                  <div className="h-5 w-1/4 rounded-md bg-gray-300"></div>
+                </div>
+              </div>
+              {/* 찜하기 아이콘 자리 */}
+              <div className="h-6 w-6 rounded-full bg-gray-300"></div>
+            </div>
+            {/* 하단 섹션 */}
+            <div className="flex items-end justify-between">
+              <div className="mt-4 flex w-3/5 flex-col gap-2 tablet:w-3/5 desktop:w-3/5">
+                <div className="flex flex-row gap-2 text-sm">
+                  <div className="flex gap-1">
+                    <div className="h-4 w-8 rounded-md bg-gray-300"></div>
+                  </div>
+                  <div className="h-4 w-12 rounded-md bg-gray-200"></div>
+                </div>
+                {/* 진행률 바 자리 */}
+                <div className="h-4 w-full rounded-md bg-gray-300"></div>
+              </div>
+              {/* 버튼 자리 */}
+              <div className="h-8 w-24 rounded-md bg-gray-300"></div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/myFavorite/gathering/_components/FavoriteGathClient.tsx
+++ b/src/app/myFavorite/gathering/_components/FavoriteGathClient.tsx
@@ -4,18 +4,17 @@ import { useEffect, useMemo, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { getFavoriteGatherings } from "@/apis/favoriteGatheringApi";
+import Toast from "@/components/Toast";
 import Card from "@/app/(home)/_components/Card";
-import CardSkeleton from "@/app/(home)/_components/Skeleton/SKCard";
+import SKCardList from "@/app/(home)/_components/Skeleton/SKCardList";
 import { GetGathering } from "@/types/components/card";
 
 type GatheringFilters = Record<string, string | number | null>;
 
 export default function FavoriteGathClient() {
   const queryClient = useQueryClient();
-
   const searchParams = useSearchParams();
 
-  // 필터 메모이제이션
   const filters = useMemo(() => {
     const f: GatheringFilters = {};
     searchParams?.forEach((value, key) => {
@@ -25,27 +24,24 @@ export default function FavoriteGathClient() {
         f[key] = value;
       }
     });
-    f.size = 4; // 페이지 크기
     return f;
   }, [searchParams]);
 
-  // React Query의 useInfiniteQuery를 사용한 페이지네이션 및 캐싱
+  // React Query로 데이터 처리**
   const { data, fetchNextPage, hasNextPage, isFetching, isLoading } = useInfiniteQuery({
-    queryKey: ["favoriteGathering", filters], // queryKey 통일
+    queryKey: ["favoriteGathering", filters],
     queryFn: async ({ pageParam = 0 }) => {
       const result = await getFavoriteGatherings({ ...filters, page: pageParam });
-
-      // API 응답 데이터의 모든 favorite 값을 true로 강제 설정
       return {
         data: result.map(gathering => ({ ...gathering, favorite: true })),
         nextPage: result.length > 0 ? pageParam + 1 : undefined,
       };
     },
-    initialPageParam: 0, // 첫 페이지 초기값
-    getNextPageParam: lastPage => lastPage.nextPage, // 다음 페이지 설정
+    initialPageParam: 0,
+    getNextPageParam: lastPage => lastPage.nextPage,
     refetchOnMount: "always",
-    staleTime: 5 * 60 * 1000, // 캐시 만료 시간
-    refetchOnWindowFocus: true, // 윈도우 포커스 시 새로고침
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: true,
   });
 
   // IntersectionObserver로 무한 스크롤 구현
@@ -54,7 +50,7 @@ export default function FavoriteGathClient() {
     const observer = new IntersectionObserver(
       entries => {
         if (entries[0].isIntersecting && hasNextPage && !isFetching) {
-          fetchNextPage(); // 다음 페이지 요청
+          fetchNextPage();
         }
       },
       { threshold: 1.0 },
@@ -65,7 +61,7 @@ export default function FavoriteGathClient() {
   }, [fetchNextPage, hasNextPage, isFetching]);
 
   const handleUpdate = () => {
-    queryClient.refetchQueries({ queryKey: ["favoriteGathering"] });
+    queryClient.invalidateQueries({ queryKey: ["favoriteGathering"] });
   };
 
   // 데이터 병합 및 중복 제거
@@ -73,11 +69,11 @@ export default function FavoriteGathClient() {
     new Map((data?.pages.flatMap(page => page.data) || []).map(item => [item.id, item])).values(),
   );
 
-  // 데이터 없을 때 화면 표시
+  // 데이터 없을 때 처리
   if (isLoading) {
     return (
-      <div className="flex h-[60vh] flex-col items-center justify-center text-gray-400">
-        <p>로딩 중...</p>
+      <div className="gathering-list my-6 flex flex-col gap-3">
+        <SKCardList />
       </div>
     );
   }
@@ -96,9 +92,7 @@ export default function FavoriteGathClient() {
       {allData.map((gathering: GetGathering) => (
         <Card key={gathering.id} cardData={gathering} onUpdate={handleUpdate} />
       ))}
-      {isFetching &&
-        Array.from({ length: 4 }).map((_, index) => <CardSkeleton key={`skeleton-${index}`} />)}
-
+      <Toast />
       <div ref={observerRef} className="h-10 w-full bg-transparent"></div>
     </div>
   );

--- a/src/app/myFavorite/gathering/page.tsx
+++ b/src/app/myFavorite/gathering/page.tsx
@@ -2,13 +2,14 @@ import { Suspense } from "react";
 import FilterSection from "@/app/(home)/_components/FilterSection";
 import HeroSection from "@/app/(home)/_components/HeroSection";
 import SelectedType from "@/app/(home)/_components/SelectedType";
+import SKCardList from "@/app/(home)/_components/Skeleton/SKCardList";
 import FavoriteGathClient from "./_components/FavoriteGathClient";
 
 function page() {
   return (
     <main className="mx-auto flex w-full max-w-[1200px] flex-col px-2 py-[59px] tablet:w-[744px] tablet:justify-start tablet:px-1.5 desktop:w-[1200px] desktop:px-0">
       <HeroSection />
-      <Suspense fallback={<div>로딩중</div>}>
+      <Suspense fallback={<SKCardList />}>
         <SelectedType />
         <FilterSection />
         <FavoriteGathClient />

--- a/src/components/Button/FavoriteButton.tsx
+++ b/src/components/Button/FavoriteButton.tsx
@@ -1,16 +1,13 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { deleteFavoriteGathering, getFavoriteGathering } from "@/apis/favoriteGatheringApi";
-import useUserStore from "@/store/userStore";
+import useToastStore from "@/store/useToastStore";
 
 export default function FavoriteButton({ gatheringId, initialFavorite }: FavoriteButtonProps) {
   const [isFavorite, setIsFavorite] = useState<boolean>(initialFavorite);
-
-  const router = useRouter();
-  const userInfo = useUserStore();
+  const addToast = useToastStore(state => state.addToast);
 
   const updateFavoriteCount = useCallback(async () => {
     try {
@@ -19,24 +16,19 @@ export default function FavoriteButton({ gatheringId, initialFavorite }: Favorit
         : getFavoriteGathering(gatheringId));
       if (response.code !== "HOST_CANNOT_FAVORITE") {
         setIsFavorite(prev => !prev);
+        addToast({ message: response.message, type: "success" });
+      } else {
+        addToast({ message: response.message, type: "error" });
       }
     } catch (error) {
       console.error("업데이트 실패", error);
     }
-  }, [gatheringId, isFavorite]); // 의존성 배열은 그대로
-
-  const submitFavorite = useCallback(async () => {
-    if (!userInfo) {
-      router.push("/signin");
-      return;
-    }
-    await updateFavoriteCount();
-  }, [userInfo, router, updateFavoriteCount]);
+  }, [gatheringId, isFavorite, addToast]); // 의존성 배열은 그대로
 
   return (
     <>
       <motion.button
-        onClick={submitFavorite}
+        onClick={updateFavoriteCount}
         className={`relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-full outline-none ${isFavorite || "border-2 border-[#E5E7EB] bg-white"}`}
         initial={{ scale: 1 }}
         whileTap={{ scale: 0.9 }} // 클릭 시 약간의 축소 효과

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import useToastStore from "@/store/useToastStore";
+
+function Toast() {
+  const toasts = useToastStore(state => state.toasts);
+  const removeToast = useToastStore(state => state.removeToast);
+
+  return (
+    <div className="fixed bottom-10 left-1/2 z-50 min-w-[200px] -translate-x-1/2 space-y-2">
+      {toasts.map(toast => (
+        <div
+          key={toast.id}
+          className={`rounded-lg px-4 py-2 text-sm font-medium shadow-lg ${
+            toast.type === "success"
+              ? "bg-yellow-primary"
+              : toast.type === "error"
+                ? "bg-red-400"
+                : "bg-blue-400"
+          } text-white`}
+          role="alert"
+        >
+          <div className="flex items-center justify-between space-x-2">
+            <span className="t">{toast.message}</span>
+            <button
+              className="ml-2 text-white hover:text-gray-200"
+              onClick={() => removeToast(toast.id)}
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default Toast;

--- a/src/constants/filter.ts
+++ b/src/constants/filter.ts
@@ -16,8 +16,8 @@ export const SORT_OPTIONS = [
 ];
 
 export const DIRECTION_OPTIONS = [
-  { ko: "최신 순", eng: "desc" },
-  { ko: "오래된 순", eng: "asc" },
+  { ko: "마감 여유", eng: "desc" },
+  { ko: "마감 임박", eng: "asc" },
 ];
 
 export const REVIEW_SORT_OPTIONS = [

--- a/src/utils/formHandler.ts
+++ b/src/utils/formHandler.ts
@@ -152,6 +152,7 @@ export const handleKeywordDelete = (
 export const handleSubmitToServer = async (
   data: CreateGatheringFormData,
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>,
+  addToast: (toast: { message: string; type: "success" | "error" }) => void,
 ) => {
   const formDataToSend = new FormData();
 
@@ -173,11 +174,14 @@ export const handleSubmitToServer = async (
       body: formDataToSend,
     });
     if (!response.ok) throw new Error("서버 응답 오류!");
-    alert("모임이 성공적으로 생성되었습니다!");
     setIsOpen(false);
+    addToast({ message: "모임이 성공적으로 생성되었습니다!", type: "success" });
   } catch (error) {
     console.error("Error submitting form:", error);
-    alert("오류가 발생했습니다. 다시 시도해주세요.");
+    addToast({
+      message: error instanceof Error ? error.message : "오류가 발생했습니다. 다시 시도해주세요.",
+      type: "error",
+    });
   }
 };
 

--- a/src/utils/formHandler.ts
+++ b/src/utils/formHandler.ts
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction } from "react";
+import { useRouter } from "next/navigation";
 import { UseFormSetValue } from "react-hook-form";
 import fetchWithMiddleware from "@/apis/fetchWithMiddleware";
 
@@ -153,6 +154,7 @@ export const handleSubmitToServer = async (
   data: CreateGatheringFormData,
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>,
   addToast: (toast: { message: string; type: "success" | "error" }) => void,
+  router: ReturnType<typeof useRouter>,
 ) => {
   const formDataToSend = new FormData();
 
@@ -173,9 +175,16 @@ export const handleSubmitToServer = async (
       method: "POST",
       body: formDataToSend,
     });
+    const responseData = await response.json();
     if (!response.ok) throw new Error("서버 응답 오류!");
     setIsOpen(false);
     addToast({ message: "모임이 성공적으로 생성되었습니다!", type: "success" });
+    // router.push로 이동
+    if (responseData?.id) {
+      router.push(`/groupDetail/${responseData.id}`);
+    } else {
+      throw new Error("서버에서 ID를 반환하지 않았습니다.");
+    }
   } catch (error) {
     console.error("Error submitting form:", error);
     addToast({


### PR DESCRIPTION
## #️⃣연관된 이슈

[MNM-146]

## 📝작업 내용

### MainPage & 찜한 모임

- 메인페이지 로딩 fallback 스켈레톤 6개 컴포넌트 만들어 적용
- 메인페이지 : 리다이렉트 시 업데이트 : 상한 데이터->프레쉬 데이터로 받도록 설정
- 정렬 텍스트 교체 (최신 순/오래된 순 => 마감 여유/마감 임박)
- alert -> toast로 교체 ( 모임생성, 버튼 : 찜하기,참여하기 )
- 찜한 모임 : 로그인 회원전용페이지로 변경
- 찜하기,참여하기 버튼에서 로그인 여부 묻는 로직 삭제 (앞으로 미들웨어에서 처리함)
---

### 모임생성

모임 생성하면 해당 상세페이지로 이동


---
### Redirect
- 로그인 시 왔던 페이지로 리다이렉트 
- fetchWithMiddleware : 토큰확인 실패시 (토큰이 없을 때) 로그인 페이지로 이동,리다이렉트 페이지 기억
  (마이페이지,찜한모임 등등)
  

### 스크린샷 (선택)
| **이미지 1**                                                                                     | **이미지 2**                                                                                     |
|:------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------:|
| ![이미지 1](https://github.com/user-attachments/assets/a1efbec8-e4f7-414f-93eb-fc08a6f87513) | ![이미지 2](https://github.com/user-attachments/assets/278e9385-6230-4d1f-b181-7d1a35d200df) |





## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


[MNM-146]: https://daremfit.atlassian.net/browse/MNM-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ