### PR TITLE
[MNM-150]refactor: 모임찜하기 버튼 색

### DIFF
--- a/src/app/(home)/_components/Card.tsx
+++ b/src/app/(home)/_components/Card.tsx
@@ -25,7 +25,7 @@ export default function Card({
           src={
             cardData.image && cardData.image.trim() !== ""
               ? cardData.image
-              : "/images/mainPage/ex-images/muckit.svg"
+              : "/images/default-gathering.svg"
           }
           alt="food"
           width={272}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -13,17 +13,17 @@ function Toast() {
           key={toast.id}
           className={`rounded-lg px-4 py-2 text-sm font-medium shadow-lg ${
             toast.type === "success"
-              ? "bg-yellow-primary"
+              ? "bg-yellow-primary text-black"
               : toast.type === "error"
-                ? "bg-red-400"
-                : "bg-blue-400"
-          } text-white`}
+                ? "bg-red-400 text-white"
+                : "bg-blue-400 text-white"
+          }`}
           role="alert"
         >
           <div className="flex items-center justify-between space-x-2">
             <span className="t">{toast.message}</span>
             <button
-              className="ml-2 text-white hover:text-gray-200"
+              className={`ml-2 hover:text-gray-200 ${toast.type === "success" ? "text-black" : "text-white"}`}
               onClick={() => removeToast(toast.id)}
             >
               ✕


### PR DESCRIPTION
## #️⃣연관된 이슈

[MNM-150]

## 📝작업 내용

메인페이지 카드 컴포넌트 기본 이미지 변경
토스트 글자 색상 변경 (기본 - 검정 ,나머지 동일)

### 스크린샷 (선택)
![스크린샷 2025-01-06 오전 9 04 55](https://github.com/user-attachments/assets/d63be195-c92b-4a80-8afe-6cf1493a9cdd)
![스크린샷 2025-01-06 오전 9 05 10](https://github.com/user-attachments/assets/bffe8e6e-9cd7-404e-a656-55b7c345d71f)
![스크린샷 2025-01-06 오전 9 06 05](https://github.com/user-attachments/assets/97030000-d2f5-49b1-95e1-fd4c0e050ad6)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


[MNM-150]: https://daremfit.atlassian.net/browse/MNM-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ