### PR TITLE
[MNM-41] refactor: 상세페이지 리팩토링

### DIFF
--- a/src/app/groupDetail/[id]/page.tsx
+++ b/src/app/groupDetail/[id]/page.tsx
@@ -1,19 +1,78 @@
 import { Metadata } from "next";
 import { cookies } from "next/headers";
 import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
-import { getReviews, getReviewsRating } from "@/apis/reviewsApi";
-import { getGatheringDetail } from "@/apis/searchGatheringApi";
+import fetchWithMiddleware from "@/apis/fetchWithMiddleware";
+import buildQueryParams from "@/hooks/queryParams";
 import GroupDetail from "@/app/groupDetail/_components/GroupDetail";
+import { GetReviews, GetReviewsRating } from "@/types/api/reviews";
 
 async function getGatheringServer(id: string) {
   const accessToken = cookies().get("access-token")?.value;
 
-  const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/gatherings/${id}`, {
-    headers: {
-      ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
-    },
-  });
-  return response.json();
+  try {
+    const response = await fetchWithMiddleware(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/gatherings/${id}`,
+      {
+        headers: {
+          ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`${response.status}: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("getGatheringServer Error:", error);
+    throw error;
+  }
+}
+
+async function getReviewsServer(params: GetReviews) {
+  const searchParams = new URLSearchParams();
+  if (params) {
+    buildQueryParams(searchParams, params);
+  }
+
+  try {
+    const response = await fetchWithMiddleware(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/reviews?${searchParams.toString()}`,
+    );
+
+    if (!response.ok) {
+      throw new Error(`${response.status}: ${response.statusText}`);
+    }
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("getReviewsServer Error:", error);
+    throw error;
+  }
+}
+
+async function getReviewRatingServer(params: GetReviewsRating) {
+  const searchParams = new URLSearchParams();
+  if (params) {
+    buildQueryParams(searchParams, params);
+  }
+
+  try {
+    const response = await fetchWithMiddleware(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/reviews/score?${searchParams.toString()}`,
+    );
+
+    if (!response.ok) {
+      throw new Error(`${response.status}: ${response.statusText}`);
+    }
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("getReviewRatingServer Error:", error);
+    throw error;
+  }
 }
 
 export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
@@ -45,17 +104,17 @@ async function GroupDetailPage({ params }: { params: { id: string } }) {
 
   await queryClient.prefetchQuery({
     queryKey: ["gatheringDetail", id],
-    queryFn: () => getGatheringDetail(id),
+    queryFn: () => getGatheringServer(params.id),
   });
 
   await queryClient.prefetchQuery({
-    queryKey: ["gatheringReviews", id],
-    queryFn: () => getReviews({ gatheringId: id, size: 4, page: 0 }),
+    queryKey: ["gatheringReviews", id, 0],
+    queryFn: () => getReviewsServer({ gatheringId: id, size: 4, page: 0 }),
   });
 
   await queryClient.prefetchQuery({
     queryKey: ["gatheringReviewRating", id],
-    queryFn: () => getReviewsRating({ gatheringId: id }),
+    queryFn: () => getReviewRatingServer({ gatheringId: id }),
   });
 
   return (

--- a/src/app/groupDetail/_components/DetailCard.tsx
+++ b/src/app/groupDetail/_components/DetailCard.tsx
@@ -73,6 +73,10 @@ export default function DetailCard({ gathering }: GatheringProp) {
         onClick={toggleParticipantsList}
         ref={popupRef}
         className="flex w-full grow flex-col justify-end gap-[10px] pt-3"
+        aria-expanded={isParticipantsListOpen}
+        aria-controls="participants-list-popup"
+        role="button"
+        tabIndex={0}
       >
         <div className="relative flex cursor-pointer items-center justify-between">
           <div className="flex items-center">
@@ -88,26 +92,38 @@ export default function DetailCard({ gathering }: GatheringProp) {
                       style={{
                         backgroundImage: `url(${person.image || "/images/lemonProfile.svg"})`,
                       }}
+                      aria-label={
+                        person.image ? `${person.nickname} 프로필 이미지` : "기본 프로필 이미지"
+                      }
                     ></div>
                   ),
               )}
               {gathering.participantCount > 4 ? (
-                <div className="-ml-3 flex h-[29px] w-[29px] select-none items-center justify-center rounded-full bg-[#f2f4f5] text-sm font-semibold text-[#262626]">
+                <div
+                  aria-label={`추가 참석자 ${gathering.participantCount - 4}명`}
+                  className="-ml-3 flex h-[29px] w-[29px] select-none items-center justify-center rounded-full bg-[#f2f4f5] text-sm font-semibold text-[#262626]"
+                >
                   +{gathering.participantCount - 4}
                 </div>
               ) : null}
               {isParticipantsListOpen && (
                 <div
+                  id="participants-list-popup"
+                  role="dialog"
+                  aria-labelledby="participants-list-title"
                   onClick={e => e.stopPropagation()}
                   className="z-2 absolute left-0 top-9 flex min-w-[200px] cursor-default flex-col items-center justify-between rounded-2xl border bg-white p-4"
                 >
                   <div className="flex w-full items-center justify-between">
                     <div className="h-4 w-4"></div>
-                    <h3 className="text-sm font-semibold">참석자 목록</h3>
+                    <h3 id="participants-list-title" className="text-sm font-semibold">
+                      참석자 목록
+                    </h3>
                     <button
                       onClick={closeParticipantsList}
                       className="h-[14px] w-[14px]"
                       type="button"
+                      aria-label="참석자 목록 닫기"
                     >
                       <Image src="/icons/X.svg" width={14} height={14} alt="닫기" />
                     </button>
@@ -120,6 +136,10 @@ export default function DetailCard({ gathering }: GatheringProp) {
                         style={{
                           backgroundImage: `url(${person.image || "/images/lemonProfile.svg"})`,
                         }}
+                        aria-label={
+                          person.image ? `${person.nickname} 프로필 이미지` : "기본 프로필 이미지"
+                        }
+                        tabIndex={0}
                       ></div>
                       <p className="text-sm font-semibold"> {person.nickname}</p>
                     </div>

--- a/src/app/groupDetail/_components/DetailCard.tsx
+++ b/src/app/groupDetail/_components/DetailCard.tsx
@@ -74,11 +74,11 @@ export default function DetailCard({ gathering }: GatheringProp) {
         ref={popupRef}
         className="flex w-full grow flex-col justify-end gap-[10px] pt-3"
       >
-        <div className="flex cursor-pointer items-center justify-between">
+        <div className="relative flex cursor-pointer items-center justify-between">
           <div className="flex items-center">
             <p className="text-sm font-semibold">모집 정원 {gathering.participantCount}명</p>
 
-            <div className="relative ml-4 flex">
+            <div className="ml-4 flex">
               {gathering.participants.map(
                 (person, index) =>
                   index < 4 && (
@@ -86,7 +86,7 @@ export default function DetailCard({ gathering }: GatheringProp) {
                       key={index}
                       className="-ml-3 h-[29px] w-[29px] cursor-pointer rounded-full bg-cover bg-center"
                       style={{
-                        backgroundImage: `url(${person.image || "/images/profile.svg"})`,
+                        backgroundImage: `url(${person.image || "/images/lemonProfile.svg"})`,
                       }}
                     ></div>
                   ),
@@ -99,29 +99,31 @@ export default function DetailCard({ gathering }: GatheringProp) {
               {isParticipantsListOpen && (
                 <div
                   onClick={e => e.stopPropagation()}
-                  className="absolute -left-3 top-9 z-10 flex min-w-[200px] cursor-default flex-col items-center justify-between rounded-2xl border bg-white p-4"
+                  className="z-2 absolute left-0 top-9 flex min-w-[200px] cursor-default flex-col items-center justify-between rounded-2xl border bg-white p-4"
                 >
-                  <h3 className="mb-3 border-b-2 border-gray-100 text-center font-semibold">
-                    참석자 목록
-                  </h3>
+                  <div className="flex w-full items-center justify-between">
+                    <div className="h-4 w-4"></div>
+                    <h3 className="text-sm font-semibold">참석자 목록</h3>
+                    <button
+                      onClick={closeParticipantsList}
+                      className="h-[14px] w-[14px]"
+                      type="button"
+                    >
+                      <Image src="/icons/X.svg" width={14} height={14} alt="닫기" />
+                    </button>
+                  </div>
+
                   {gathering.participants.map(person => (
                     <div className="mt-2 flex w-full items-center gap-2" key={person.userId}>
                       <div
                         className="h-[24px] w-[24px] rounded-full bg-cover bg-center"
                         style={{
-                          backgroundImage: `url(${person.image || "/images/profile.svg"})`,
+                          backgroundImage: `url(${person.image || "/images/lemonProfile.svg"})`,
                         }}
                       ></div>
                       <p className="text-sm font-semibold"> {person.nickname}</p>
                     </div>
                   ))}
-                  <button
-                    onClick={closeParticipantsList}
-                    className="mt-6 h-[32px] rounded-xl bg-[#dfe0e1] px-4 text-sm font-semibold"
-                    type="button"
-                  >
-                    닫기
-                  </button>
                 </div>
               )}
             </div>

--- a/src/app/groupDetail/_components/FixedBottomBar.tsx
+++ b/src/app/groupDetail/_components/FixedBottomBar.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { CancelGathering, LeaveGathering, joinGathering } from "@/apis/assignGatheringApi";
 import Button from "@/components/Button/Button";
 import useUserStore from "@/store/userStore";
@@ -26,6 +27,8 @@ export default function FixedBottomBar({
 
   const userInfo = useUserStore();
   const router = useRouter();
+
+  const queryClient = useQueryClient();
 
   const isParticipating = useMemo(
     () => data.participants.some(participant => participant.userId === userInfo.id),
@@ -75,6 +78,7 @@ export default function FixedBottomBar({
 
       onShowToast("모임에 참여되었습니다.", "success");
       setStatus("cancelJoin");
+      await queryClient.invalidateQueries({ queryKey: ["gatheringDetail"] });
     } catch (err) {
       console.error("Failed to join gathering:", err);
       onShowToast("예기치 않은 오류가 발생했습니다. 다시 시도해주시기 바랍니다.", "error");
@@ -90,6 +94,7 @@ export default function FixedBottomBar({
 
       onShowToast("모임 참여가 취소되었습니다.", "success");
       setStatus("join");
+      await queryClient.invalidateQueries({ queryKey: ["gatheringDetail"] });
     } catch (err) {
       console.error("Failed to leave gathering:", err);
       onShowToast("예기치 않은 오류가 발생했습니다. 다시 시도해주시기 바랍니다.", "error");
@@ -167,13 +172,21 @@ export default function FixedBottomBar({
         )}
 
         {status === "closed" && (
-          <Button className="h-11 w-[115px] bg-[#9CA3AF] text-white tablet:grow-0" disabled>
+          <Button
+            aria-disabled="true"
+            className="h-11 w-[115px] bg-[#9CA3AF] text-white tablet:grow-0"
+            disabled
+          >
             모임 마감
           </Button>
         )}
 
         {status === "canceled" && (
-          <Button className="h-11 w-[124px] bg-[#9CA3AF] text-white tablet:grow-0" disabled>
+          <Button
+            aria-disabled="true"
+            className="h-11 w-[124px] bg-[#9CA3AF] text-white tablet:grow-0"
+            disabled
+          >
             취소된 모임
           </Button>
         )}

--- a/src/app/groupDetail/_components/GroupDetail.tsx
+++ b/src/app/groupDetail/_components/GroupDetail.tsx
@@ -60,7 +60,6 @@ function GroupDetail({ paramsId }: { paramsId: number }) {
                   objectFit: "cover",
                   objectPosition: "center",
                 }}
-                className="z-0"
                 priority
               />
               <ClosingTimeTag deadline={detail.registrationEnd} />
@@ -81,17 +80,20 @@ function GroupDetail({ paramsId }: { paramsId: number }) {
                       backgroundImage: `url(${detail.user.image || "/images/profile.svg"})`,
                     }}
                   ></div>
-                  <span>{detail.user.nickname}</span>
+                  <span aria-label="작성자 닉네임">{detail.user.nickname}</span>
                 </div>
                 <span className="text-[#3C3C3C]">|</span>
-                <span className="text-[#9CA3AF]">
+                <span aria-label="작성 날짜" className="text-[#9CA3AF]">
                   {formatToKoreanTime(detail.createdAt, "yyyy.MM.dd")}
                 </span>
               </div>
             </section>
 
             {detail.address2 && (
-              <section className="desktop:grid-area-bottomRight tablet:col-span-2 tablet:h-[206px] tablet:px-6 desktop:px-0">
+              <section
+                aria-label="모임 위치"
+                className="desktop:grid-area-bottomRight tablet:col-span-2 tablet:h-[206px] tablet:px-6 desktop:px-0"
+              >
                 <Map address={detail.address2} />
               </section>
             )}

--- a/src/app/groupDetail/_components/Map.tsx
+++ b/src/app/groupDetail/_components/Map.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 
 type MapProps = {
@@ -10,6 +10,10 @@ type MapProps = {
 const KAKAO_SDK_URL = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAOJSKEY}&libraries=services&autoload=false`;
 
 export default function Map({ address }: MapProps) {
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isMapLoaded, setIsMapLoaded] = useState<boolean>(false);
+  const [latLng, setLatLng] = useState<{ lat: number; lng: number } | null>(null);
+
   useEffect(() => {
     if (document.getElementById("kakao-sdk")) return;
 
@@ -21,33 +25,21 @@ export default function Map({ address }: MapProps) {
 
     script.onload = () => {
       kakao.maps.load(() => {
-        const container = document.getElementById("map");
-        const options = {
-          center: new kakao.maps.LatLng(37.5665, 126.978), // 초기 지도
-          level: 3,
-        };
-
-        if (!container) {
-          console.error("지도를 표시할 container가 없습니다.");
-          return;
-        }
-
-        const map = new kakao.maps.Map(container, options);
         const geocoder = new kakao.maps.services.Geocoder();
 
+        // 주소 변환
         geocoder.addressSearch(address, (result, status) => {
           if (status === kakao.maps.services.Status.OK) {
-            const coords = new kakao.maps.LatLng(parseFloat(result[0].y), parseFloat(result[0].x));
-
-            new kakao.maps.Marker({
-              map,
-              position: coords,
-            });
-
-            map.setCenter(coords);
+            const newLatLng = {
+              lat: parseFloat(result[0].y),
+              lng: parseFloat(result[0].x),
+            };
+            setLatLng(newLatLng);
+            setIsMapLoaded(true); // 지도 로드 성공
           } else {
             console.error("주소 변환 실패:", status);
           }
+          setIsLoading(false);
         });
       });
     };
@@ -60,16 +52,59 @@ export default function Map({ address }: MapProps) {
     };
   }, [address]);
 
+  useEffect(() => {
+    if (!latLng) return;
+
+    const container = document.getElementById("map");
+    if (!container) {
+      console.error("지도를 표시할 container가 없습니다.");
+      return;
+    }
+
+    const coords = new kakao.maps.LatLng(latLng.lat, latLng.lng);
+    const map = new kakao.maps.Map(container, { center: coords, level: 3 });
+
+    new kakao.maps.Marker({
+      map,
+      position: coords,
+    });
+
+    map.setCenter(coords);
+  }, [latLng]);
+
   return (
     <div className="h-full w-full">
-      <div className="h-[336px] w-full rounded-2xl bg-gray-100 tablet:h-[180px]">
-        <div id="map" style={{ width: "100%", height: "100%", borderRadius: "16px" }} />
-      </div>
+      {isLoading ? (
+        // 로딩 중
+        <div className="flex h-[336px] w-full items-center justify-center rounded-2xl bg-gray-100 tablet:h-[180px]">
+          <div className="h-6 w-6 animate-spin rounded-full border-4 border-gray-300 border-t-transparent" />
+        </div>
+      ) : isMapLoaded ? (
+        // 지도 로드 성공
+        <div className="h-[336px] w-full rounded-2xl bg-gray-100 tablet:h-[180px]">
+          <div
+            role="region"
+            aria-label={`${address} 주변 지도`}
+            id="map"
+            style={{ width: "100%", height: "100%", borderRadius: "16px" }}
+          />
+        </div>
+      ) : (
+        //지도 로드 실패
+        <div className="flex h-[336px] w-full items-center justify-center rounded-2xl bg-gray-100 tablet:h-[180px]">
+          <p className="text-center text-sm font-medium text-gray-500">
+            지도를 불러오는 데 문제가 발생했습니다. &#128549; <br />
+            잠시 후 다시 시도해 주세요.
+          </p>
+        </div>
+      )}
       <div className="mt-2 flex items-center gap-1">
         <div className="flex size-[18px] items-center justify-center">
           <Image src="/images/detailPage/location.svg" alt="위치" width={12} height={16} />
         </div>
-        <p className="text-sm font-medium text-[#3C3C3C]">{address}</p>
+        <p aria-label={`모임 장소 주소: ${address}`} className="text-sm font-medium text-[#3C3C3C]">
+          {address}
+        </p>
       </div>
     </div>
   );

--- a/src/app/groupDetail/_components/ReviewRatingComponent.tsx
+++ b/src/app/groupDetail/_components/ReviewRatingComponent.tsx
@@ -34,7 +34,9 @@ export default function ReviewRatingComponent({
     <div className="flex h-[180px] w-full items-center justify-center gap-5 tablet:gap-[120px]">
       <div className="flex max-w-[128px] flex-col items-center justify-center text-2xl font-semibold">
         <div>
-          <span className="mr-[2px]">{ratingScores?.averageScore.toFixed(1)}</span>
+          <span aria-label="평균 평점" className="mr-[2px]">
+            {ratingScores?.averageScore.toFixed(1)}
+          </span>
           <span className="text-[#9CA3AF]">/5</span>
         </div>
         <div className="flex items-center">
@@ -43,7 +45,7 @@ export default function ReviewRatingComponent({
               <Image
                 width={24}
                 height={22}
-                alt="평점"
+                alt="평점 하트 이미지"
                 src={
                   index < ratingScores?.averageScore
                     ? "/images/heart/filled_heart.svg"

--- a/src/app/groupDetail/_components/Reviews.tsx
+++ b/src/app/groupDetail/_components/Reviews.tsx
@@ -49,19 +49,27 @@ export default function Reviews({ gatheringId }: { gatheringId: number }) {
   const handlePrevPage = () => setPage(prev => Math.max(prev - 1, 0));
   const handleNextPage = () => setPage(prev => Math.min(prev + 1, totalPages - 1));
 
-  if (reviewsError || ratingError)
-    return (
-      <div className="flex w-full items-center justify-center">
-        <p>예기치 않은 오류가 발생했습니다. 다시 시도해주시기 바랍니다.</p>
-      </div>
-    );
-
   return (
     <div className="bg-white px-4 py-6 tablet:col-span-2 tablet:px-6 tablet:pb-[87px]">
       <div className="min-h-[500px]">
         <h3 className="mb-5 text-lg font-semibold">
           리뷰 <span>{isRatingLoading || `(${totalReviews})`}</span>
         </h3>
+
+        <div className="my-4 border-y border-[#E5E7EB]">
+          {isRatingLoading ? (
+            <ReviewRatingSkeleton />
+          ) : ratingError ? (
+            <div className="flex w-full flex-col items-center justify-center">
+              <p>예기치 않은 오류가 발생했습니다. &#128549;</p>
+              <p>잠시 후 다시 시도해 주세요.</p>
+            </div>
+          ) : (
+            ratingData && (
+              <ReviewRatingComponent ratingData={ratingData[0]} totalReviews={totalReviews || 0} />
+            )
+          )}
+        </div>
 
         {isReviewsLoading ? (
           <div className="h-full w-full">
@@ -70,23 +78,16 @@ export default function Reviews({ gatheringId }: { gatheringId: number }) {
             <ReviewSkeleton />
             <ReviewSkeleton />
           </div>
+        ) : reviewsError ? (
+          <div className="flex w-full flex-col items-center justify-center">
+            <p>예기치 않은 오류가 발생했습니다. &#128549;</p>
+            <p>잠시 후 다시 시도해 주세요.</p>
+          </div>
         ) : reviews && reviews.length > 0 ? (
-          <div className="mt-4">
-            <div className="mb-4 border-y border-[#E5E7EB]">
-              {isRatingLoading ? (
-                <ReviewRatingSkeleton />
-              ) : (
-                ratingData && (
-                  <ReviewRatingComponent
-                    ratingData={ratingData[0]}
-                    totalReviews={totalReviews || 0}
-                  />
-                )
-              )}
-            </div>
-            <div className="flex flex-col gap-[10px]">
+          <div>
+            <ul className="flex flex-col gap-[10px]">
               {reviews.map(review => (
-                <div key={review.id} className="border-b-2 border-dashed border-[#F3F4F6] pb-4">
+                <li key={review.id} className="border-b-2 border-dashed border-[#F3F4F6] pb-4">
                   <div className="flex h-[86px] flex-col justify-between">
                     <div className="flex">
                       {Array.from({ length: 5 }).map((_, index) => (
@@ -94,7 +95,7 @@ export default function Reviews({ gatheringId }: { gatheringId: number }) {
                           <Image
                             width={24}
                             height={22}
-                            alt="평점"
+                            alt="평점 하트 이미지"
                             src={
                               index < review.score
                                 ? "/images/heart/filled_heart.svg"
@@ -113,25 +114,35 @@ export default function Reviews({ gatheringId }: { gatheringId: number }) {
                           style={{
                             backgroundImage: `url(${review.user.image || "/images/profile.svg"})`,
                           }}
+                          aria-label={
+                            review.user.image
+                              ? `${review.user.nickname} 프로필 이미지`
+                              : "기본 프로필 이미지"
+                          }
                         ></div>
-                        <span className="text-[#3d3d3d]">{review.user.nickname}</span>
+                        <span aria-label="작성자 닉네임" className="text-[#3d3d3d]">
+                          {review.user.nickname}
+                        </span>
                       </div>
                       <span className="text-[#3C3C3C]">|</span>
 
-                      <span className="text-[#9CA3AF]">
+                      <span aria-label="작성 날짜" className="text-[#9CA3AF]">
                         {formatToKoreanTime(review?.createdAt, "yyyy.MM.dd")}
                       </span>
                     </div>
                   </div>
-                </div>
+                </li>
               ))}
-            </div>
+            </ul>
+
             <div className="mt-5 flex w-full items-center justify-center gap-4">
               <button
                 className={`flex h-6 w-6 items-center justify-center border ${page === 0 ? "invisible" : "visible"}`}
                 type="button"
                 onClick={handlePrevPage}
                 disabled={page === 0}
+                aria-label="이전 페이지로 이동"
+                aria-disabled={page === 0}
               >
                 <Image src="/icons/chevron_left.svg" width={22} height={22} alt="이전" />
               </button>
@@ -145,14 +156,17 @@ export default function Reviews({ gatheringId }: { gatheringId: number }) {
                 type="button"
                 onClick={handleNextPage}
                 disabled={page >= totalPages - 1}
+                aria-label="다음 페이지로 이동"
+                aria-disabled={page >= totalPages - 1}
               >
                 <Image src="/icons/chevron_right.svg" width={22} height={22} alt="다음" />
               </button>
             </div>
           </div>
         ) : (
-          <div className="flex h-[200px] w-full items-center justify-center">
-            <p className="text-[#9CA3AF]">아직 리뷰가 없어요</p>
+          <div className="flex h-[200px] w-full flex-col items-center justify-center text-sm font-medium text-[#9CA3AF]">
+            <p>아직 리뷰가 없어요. &#x1F4AD;</p>
+            <p>첫 번째 리뷰를 기다리고 있어요!</p>
           </div>
         )}
       </div>

--- a/src/app/groupDetail/_components/Skeleton/ReviewRatingSkeleton.tsx
+++ b/src/app/groupDetail/_components/Skeleton/ReviewRatingSkeleton.tsx
@@ -16,7 +16,7 @@ export default function ReviewRatingSkeleton() {
     <div className="flex h-[180px] w-full items-center justify-center gap-5 tablet:gap-[120px]">
       <div className="flex max-w-[128px] flex-col items-center justify-center text-2xl font-semibold">
         <div>
-          <span className="mr-[2px]">0.0</span>
+          <span className="mr-[2px]">0</span>
           <span className="text-[#9CA3AF]">/5</span>
         </div>
         <div className="flex items-center">

--- a/src/components/Button/FavoriteButton.tsx
+++ b/src/components/Button/FavoriteButton.tsx
@@ -32,6 +32,8 @@ export default function FavoriteButton({ gatheringId, initialFavorite }: Favorit
         className={`relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-full outline-none ${isFavorite || "border-2 border-[#E5E7EB] bg-white"}`}
         initial={{ scale: 1 }}
         whileTap={{ scale: 0.9 }} // 클릭 시 약간의 축소 효과
+        aria-pressed={isFavorite}
+        aria-label={isFavorite ? "찜하기 취소" : "찜하기"}
       >
         <motion.div
           className="absolute inset-0 rounded-full"
@@ -44,7 +46,7 @@ export default function FavoriteButton({ gatheringId, initialFavorite }: Favorit
         />
         <motion.img
           src={isFavorite ? "/images/heart/filled_heart.svg" : "/images/heart/empty_heart.svg"}
-          alt="like"
+          alt={isFavorite ? "찜한 상태" : "찜 추가 가능"}
           className="relative z-10 h-6 w-6"
           key={isFavorite ? "filled-heart" : "empty-heart"}
           initial={{ scale: 0.8 }}

--- a/src/components/Button/FavoriteButton.tsx
+++ b/src/components/Button/FavoriteButton.tsx
@@ -26,34 +26,32 @@ export default function FavoriteButton({ gatheringId, initialFavorite }: Favorit
   }, [gatheringId, isFavorite, addToast]); // 의존성 배열은 그대로
 
   return (
-    <>
-      <motion.button
-        onClick={updateFavoriteCount}
-        className={`relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-full outline-none ${isFavorite || "border-2 border-[#E5E7EB] bg-white"}`}
-        initial={{ scale: 1 }}
-        whileTap={{ scale: 0.9 }} // 클릭 시 약간의 축소 효과
-        aria-pressed={isFavorite}
-        aria-label={isFavorite ? "찜하기 취소" : "찜하기"}
-      >
-        <motion.div
-          className="absolute inset-0 rounded-full"
-          initial={{ opacity: 0, backgroundColor: isFavorite ? "#FFFACD" : "#FFFFFF" }}
-          animate={{
-            opacity: isFavorite ? 0.3 : 0,
-            backgroundColor: isFavorite ? "#FFFACD" : "#FFFFFF",
-          }}
-          transition={{ duration: 0.3 }}
-        />
-        <motion.img
-          src={isFavorite ? "/images/heart/filled_heart.svg" : "/images/heart/empty_heart.svg"}
-          alt={isFavorite ? "찜한 상태" : "찜 추가 가능"}
-          className="relative z-10 h-6 w-6"
-          key={isFavorite ? "filled-heart" : "empty-heart"}
-          initial={{ scale: 0.8 }}
-          animate={{ scale: 1 }}
-          transition={{ duration: 0.3 }}
-        />
-      </motion.button>
-    </>
+    <motion.button
+      onClick={updateFavoriteCount}
+      className={`relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-full ${isFavorite || "border-2 border-[#E5E7EB] bg-white"}`}
+      initial={{ scale: 1 }}
+      whileTap={{ scale: 0.9 }} // 클릭 시 약간의 축소 효과
+      aria-pressed={isFavorite}
+      aria-label={isFavorite ? "찜하기 취소" : "찜하기"}
+    >
+      <motion.div
+        className="absolute inset-0 rounded-full"
+        initial={{ opacity: 0, backgroundColor: isFavorite ? "#FFFACD" : "#FFFFFF" }}
+        animate={{
+          opacity: isFavorite ? 0.3 : 0,
+          backgroundColor: isFavorite ? "#FFFACD" : "#FFFFFF",
+        }}
+        transition={{ duration: 0.3 }}
+      />
+      <motion.img
+        src={isFavorite ? "/images/heart/filled_heart.svg" : "/images/heart/empty_heart.svg"}
+        alt={isFavorite ? "찜한 상태" : "찜 추가 가능"}
+        className="relative z-10 h-6 w-6"
+        key={isFavorite ? "filled-heart" : "empty-heart"}
+        initial={{ scale: 0.8 }}
+        animate={{ scale: 1 }}
+        transition={{ duration: 0.3 }}
+      />
+    </motion.button>
   );
 }

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -39,7 +39,19 @@ function DateCell({
     }[type];
 
   return (
-    <td onClick={handleClick} className="flex h-8 w-9 cursor-pointer text-center">
+    <td
+      role="gridcell"
+      aria-selected={isFirstDate || isSecondDate ? "true" : "false"}
+      aria-disabled={isPastDay ? "true" : undefined}
+      tabIndex={isPastDay ? -1 : 0}
+      onClick={handleClick}
+      onKeyDown={e => {
+        if (e.key === "Enter" && !isPastDay) {
+          handleClick?.();
+        }
+      }}
+      className="flex h-8 w-9 cursor-pointer text-center"
+    >
       <span
         className={`flex h-full w-full select-none items-center justify-center rounded-[8px] ${isFirstDate && "bg-yellow-primary"} ${isSecondDate && "bg-[#FF9E48]"} ${(type === "prev" || type === "next" || isPastDay) && "text-gray-300"} ${isInRange && "bg-gray-200"} `}
       >
@@ -145,7 +157,7 @@ export default function Calendar({ selectMode, multipleDates }: CalendarProps) {
   return (
     <div className="flex w-[280px] flex-col items-center justify-center rounded-[12px] bg-white py-3">
       <div className="mb-1 flex h-8 w-[250px] items-center justify-between">
-        <button type="button" onClick={handlePrevMonth}>
+        <button aria-label="이전 달로 이동" type="button" onClick={handlePrevMonth}>
           <Image
             className="rotate-180"
             src="/images/ic_arrow.png"
@@ -158,16 +170,16 @@ export default function Calendar({ selectMode, multipleDates }: CalendarProps) {
           <span>{MONTH_OF_YEAR[month]}</span>
           <span>{year}</span>
         </div>
-        <button type="button" onClick={handleNextMonth}>
+        <button aria-label="다음 달로 이동" type="button" onClick={handleNextMonth}>
           <Image src="/images/ic_arrow.png" alt="next month" width={24} height={24} />
         </button>
       </div>
 
-      <table className="w-[250px] table-fixed">
+      <table role="grid" aria-label={`${year}년 ${month + 1}월`} className="w-[250px] table-fixed">
         <thead>
-          <tr className="flex w-[250px] justify-between">
+          <tr role="row" className="flex w-[250px] justify-between">
             {DAYS_OF_WEEK.map(day => (
-              <th className="h-8 w-9 select-none text-center" key={day}>
+              <th role="columnheader" className="h-8 w-9 select-none text-center" key={day}>
                 {day}
               </th>
             ))}
@@ -175,7 +187,7 @@ export default function Calendar({ selectMode, multipleDates }: CalendarProps) {
         </thead>
         <tbody className="flex w-[250px] flex-col justify-between">
           {Array.from({ length: Math.ceil(allDates.length / 7) }).map((_, rowIndex) => (
-            <tr className="flex w-[250px] justify-between" key={rowIndex}>
+            <tr role="row" className="flex w-[250px] justify-between" key={rowIndex}>
               {allDates.slice(rowIndex * 7, rowIndex * 7 + 7).map(({ date, type }, colIndex) => (
                 <DateCell
                   key={colIndex}

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -17,27 +17,31 @@ function DateCell({
   onNavigateToNextMonth,
 }: DateCellProps) {
   const selectedDate = `${currentDate.getFullYear()}-${String(currentDate.getMonth() + 1).padStart(2, "0")}-${String(date).padStart(2, "0")}`;
-
-  const todayKST = new Date(today.getTime() + 9 * 60 * 60 * 1000); // KST 기준으로 보정
-  const isToday = type === "current" && todayKST.toISOString().slice(0, 10) === selectedDate;
-
   const isFirstDate = type === "current" && firstDate && firstDate.slice(0, 10) === selectedDate;
-
   const isSecondDate = type === "current" && secondDate && secondDate.slice(0, 10) === selectedDate;
-  const handleClick = {
-    current: onSelectDate,
-    prev: onNavigateToPrevMonth,
-    next: onNavigateToNextMonth,
-  }[type];
+
+  const isPastDay =
+    type === "current" && new Date(currentDate.getFullYear(), currentDate.getMonth(), date) < today;
+
+  const isInRange =
+    type === "current" &&
+    firstDate &&
+    secondDate &&
+    new Date(firstDate) < new Date(selectedDate) &&
+    new Date(selectedDate) < new Date(secondDate);
+
+  const handleClick = isPastDay
+    ? undefined
+    : {
+      current: onSelectDate,
+      prev: onNavigateToPrevMonth,
+      next: onNavigateToNextMonth,
+    }[type];
 
   return (
     <td onClick={handleClick} className="flex h-8 w-9 cursor-pointer text-center">
       <span
-        className={`flex h-full w-full select-none items-center justify-center rounded-[8px] ${
-          type === "prev" || type === "next" ? "text-gray-500" : ""
-        } ${isFirstDate ? "bg-yellow-primary text-white" : ""} ${
-          isSecondDate ? "bg-[#FF9E48] text-white" : ""
-        }${isToday && !isFirstDate ? "text-[#FF9E48]" : ""} `}
+        className={`flex h-full w-full select-none items-center justify-center rounded-[8px] ${isFirstDate && "bg-yellow-primary"} ${isSecondDate && "bg-[#FF9E48]"} ${(type === "prev" || type === "next" || isPastDay) && "text-gray-300"} ${isInRange && "bg-gray-200"} `}
       >
         {date}
       </span>
@@ -52,6 +56,7 @@ export default function Calendar({ selectMode, multipleDates }: CalendarProps) {
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
   const today = new Date();
+  today.setHours(0, 0, 0, 0);
 
   const firstDayOfMonth = useMemo(() => new Date(year, month, 1), [year, month]);
   const lastDayOfMonth = useMemo(() => new Date(year, month + 1, 0), [year, month]);

--- a/src/components/Calendar/DropdownCalendar.tsx
+++ b/src/components/Calendar/DropdownCalendar.tsx
@@ -67,6 +67,7 @@ export default function DropdownCalendar() {
         selectedDateOption={submittedDateOption}
         filterType="calendarFilter"
         onToggle={toggleDropdown}
+        isOpen={isOpen}
       />
 
       <div
@@ -77,10 +78,16 @@ export default function DropdownCalendar() {
         {/* 캘린더는 상태 변경 시 자동으로 업데이트 */}
         <Calendar multipleDates={true} />
         <div className="mb-3 flex w-full justify-around px-3">
-          <Button onClick={resetDate} size="small" className="w-[118px] bg-[#F3F4F6] font-semibold">
+          <Button
+            aria-label="날짜 선택 초기화"
+            onClick={resetDate}
+            size="small"
+            className="w-[118px] bg-[#F3F4F6] font-semibold"
+          >
             초기화
           </Button>
           <Button
+            aria-label="선택한 날짜 적용"
             onClick={submitDates}
             size="small"
             className="w-[118px] bg-yellow-primary font-semibold"

--- a/src/components/Calendar/DropdownCalendar.tsx
+++ b/src/components/Calendar/DropdownCalendar.tsx
@@ -14,6 +14,11 @@ export default function DropdownCalendar() {
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const updateQueryParams = useQueryBuilder(); // URL 파라미터 업데이트 훅
 
+  const [submittedDateOption, setSummitedDateOption] = useState<{
+    firstDate: string;
+    secondDate: string;
+  } | null>(null);
+
   // 드롭다운 열고 닫기
   const toggleDropdown = () => {
     setIsOpen(prevState => !prevState);
@@ -31,6 +36,8 @@ export default function DropdownCalendar() {
     setFirstDate(null);
     setSecondDate(null);
     updateQueryParams({ startDate: "", endDate: "" }); // 빈 문자열로 파라미터 제거
+    setSummitedDateOption(null);
+    setIsOpen(false);
   };
 
   // URL 파라미터 업데이트
@@ -44,21 +51,26 @@ export default function DropdownCalendar() {
       // URL에 반영
       updateQueryParams(queryParams);
 
+      setSummitedDateOption({
+        firstDate: firstDate ? firstDate.split("-").slice(1).join(".") : "",
+        secondDate: secondDate ? secondDate.split("-").slice(1).join(".") : "",
+      });
+
       // 드롭다운 닫기
       setIsOpen(false);
     }
   };
 
   return (
-    <div ref={dropdownRef}>
+    <div ref={dropdownRef} className="relative">
       <FilterButton
-        selectedDateOption="날짜 선택"
-        filterType="selectionFilter"
+        selectedDateOption={submittedDateOption}
+        filterType="calendarFilter"
         onToggle={toggleDropdown}
       />
 
       <div
-        className={`absolute z-50 mt-3 flex w-[300px] flex-col items-center justify-center rounded-[12px] border-[2px] border-[#F3F4F6] bg-white ${
+        className={`fixed left-1/2 top-1/2 z-50 mt-3 flex w-[300px] -translate-x-1/2 -translate-y-1/2 transform flex-col items-center justify-center rounded-[12px] border-[2px] border-[#F3F4F6] bg-white tablet:absolute tablet:left-0 tablet:top-[36px] tablet:translate-x-0 tablet:translate-y-0 ${
           isOpen ? "block" : "hidden"
         }`}
       >
@@ -71,7 +83,7 @@ export default function DropdownCalendar() {
           <Button
             onClick={submitDates}
             size="small"
-            className="w-[118px] bg-[#FFFACD] font-semibold"
+            className="w-[118px] bg-yellow-primary font-semibold"
           >
             적용
           </Button>

--- a/src/components/Filter/Dropdown.tsx
+++ b/src/components/Filter/Dropdown.tsx
@@ -1,13 +1,28 @@
-export default function Dropdown({ options, isOpen, onSelectOption, filterType }: DropdownProps) {
+export default function Dropdown({
+  options,
+  isOpen,
+  onSelectOption,
+  selectedOption,
+  filterType,
+}: DropdownProps) {
   return (
     <ul
+      role="listbox"
       className={`${isOpen ? "block" : "hidden"} ${filterType === "selectionFilter" ? "w-[110px]" : "w-[120px]"} absolute z-50 mt-3 rounded-[12px] border-[2px] border-[#F3F4F6] bg-white p-1`}
     >
-      {options.map((option, index) => (
+      {options.map(option => (
         <li
+          role="option"
+          aria-selected={selectedOption?.ko === option.ko}
           className="h-[36px] w-full select-none rounded-xl px-[12px] py-[6px] text-sm hover:bg-[#FFFACD] tablet:h-[40px] tablet:py-[8px]"
           onClick={() => onSelectOption(option)}
-          key={index}
+          tabIndex={0}
+          onKeyDown={e => {
+            if (e.key === "Enter") {
+              onSelectOption(option);
+            }
+          }}
+          key={option.ko}
         >
           {option.ko}
         </li>

--- a/src/components/Filter/FilterButton.tsx
+++ b/src/components/Filter/FilterButton.tsx
@@ -1,10 +1,15 @@
 import Image from "next/image";
 
-export default function FilterButton({ selectedOption, filterType, onToggle }: FilterButtonProps) {
+export default function FilterButton({
+  selectedDateOption,
+  selectedOption,
+  filterType,
+  onToggle,
+}: FilterButtonProps) {
   return (
-    <div onClick={onToggle}>
+    <div onClick={onToggle} className="cursor-pointer">
       {filterType === "sortFilter" && (
-        <div className="relative flex h-[36px] w-[120px] select-none items-center justify-center rounded-[12px] border-[2px] border-[#F3F4F6] bg-white px-[12px] text-sm tablet:h-[40px]">
+        <div className="relative flex h-[36px] w-[120px] select-none items-center justify-center rounded-[12px] border-[2px] border-[#F3F4F6] bg-white px-[12px] text-sm transition-all hover:bg-[#F3F4F6] tablet:h-[40px]">
           <div className="flex h-6 w-6 items-center">
             <Image src="/images/filter/swap_vert.svg" alt={filterType} width={18} height={10} />
           </div>
@@ -13,7 +18,7 @@ export default function FilterButton({ selectedOption, filterType, onToggle }: F
       )}
 
       {filterType === "selectionFilter" && (
-        <div className="relative flex h-[36px] w-[110px] select-none items-center justify-between rounded-[12px] border-[2px] border-[#F3F4F6] bg-white px-[12px] py-[6px] text-sm tablet:h-[40px] tablet:py-[8px]">
+        <div className="relative flex h-[36px] min-w-[110px] select-none items-center justify-between rounded-[12px] border-[2px] border-[#F3F4F6] px-[12px] py-[6px] text-sm transition-all hover:bg-[#F3F4F6] tablet:h-[40px] tablet:py-[8px]">
           <div className="flex h-6 w-6 items-center">
             <Image
               src="/images/filter/arrow_drop_down.svg"
@@ -22,7 +27,25 @@ export default function FilterButton({ selectedOption, filterType, onToggle }: F
               height={22}
             />
           </div>
-          <span>{selectedOption ? selectedOption.ko : "날짜 선택"}</span>
+          <span>{selectedOption && selectedOption.ko}</span>
+        </div>
+      )}
+
+      {filterType === "calendarFilter" && (
+        <div className="relative flex h-[36px] min-w-[110px] select-none items-center justify-between rounded-[12px] border-[2px] border-[#F3F4F6] px-[10px] py-[6px] text-sm transition-all hover:bg-[#F3F4F6] tablet:h-[40px] tablet:py-[8px]">
+          <div className="flex h-6 w-6 items-center">
+            <Image
+              src="/images/filter/arrow_drop_down.svg"
+              alt={filterType}
+              width={22}
+              height={22}
+            />
+          </div>
+          <span>
+            {selectedDateOption
+              ? `${selectedDateOption.firstDate} - ${selectedDateOption.secondDate}`
+              : "날짜 선택"}
+          </span>
         </div>
       )}
     </div>

--- a/src/components/Filter/FilterButton.tsx
+++ b/src/components/Filter/FilterButton.tsx
@@ -5,20 +5,41 @@ export default function FilterButton({
   selectedOption,
   filterType,
   onToggle,
+  isOpen,
 }: FilterButtonProps) {
+  const labelText =
+    filterType === "calendarFilter"
+      ? selectedDateOption
+        ? `${selectedDateOption.firstDate} - ${selectedDateOption.secondDate || selectedDateOption.firstDate}`
+        : "날짜 선택"
+      : selectedOption?.ko;
+
   return (
-    <div onClick={onToggle} className="cursor-pointer">
+    <div
+      role="button"
+      aria-haspopup={filterType === "calendarFilter" ? "grid" : "listbox"}
+      aria-label={labelText}
+      aria-expanded={isOpen}
+      onClick={onToggle}
+      tabIndex={0}
+      onKeyDown={e => {
+        if (e.key === "Enter") {
+          onToggle?.();
+        }
+      }}
+      className="cursor-pointer"
+    >
       {filterType === "sortFilter" && (
         <div className="relative flex h-[36px] w-[120px] select-none items-center justify-center rounded-[12px] border-[2px] border-[#F3F4F6] bg-white px-[12px] text-sm transition-all hover:bg-[#F3F4F6] tablet:h-[40px]">
           <div className="flex h-6 w-6 items-center">
             <Image src="/images/filter/swap_vert.svg" alt={filterType} width={18} height={10} />
           </div>
-          <span>{selectedOption?.ko}</span>
+          <span>{labelText}</span>
         </div>
       )}
 
       {filterType === "selectionFilter" && (
-        <div className="relative flex h-[36px] min-w-[110px] select-none items-center justify-between rounded-[12px] border-[2px] border-[#F3F4F6] px-[12px] py-[6px] text-sm transition-all hover:bg-[#F3F4F6] tablet:h-[40px] tablet:py-[8px]">
+        <div className="relative flex h-[36px] w-[110px] select-none items-center justify-between rounded-[12px] border-[2px] border-[#F3F4F6] px-[12px] py-[6px] text-sm transition-all hover:bg-[#F3F4F6] tablet:h-[40px] tablet:py-[8px]">
           <div className="flex h-6 w-6 items-center">
             <Image
               src="/images/filter/arrow_drop_down.svg"
@@ -27,7 +48,7 @@ export default function FilterButton({
               height={22}
             />
           </div>
-          <span>{selectedOption && selectedOption.ko}</span>
+          <span>{labelText}</span>
         </div>
       )}
 
@@ -41,11 +62,7 @@ export default function FilterButton({
               height={22}
             />
           </div>
-          <span>
-            {selectedDateOption
-              ? `${selectedDateOption.firstDate} - ${selectedDateOption.secondDate || selectedDateOption.firstDate}`
-              : "날짜 선택"}
-          </span>
+          <span>{labelText}</span>
         </div>
       )}
     </div>

--- a/src/components/Filter/FilterButton.tsx
+++ b/src/components/Filter/FilterButton.tsx
@@ -43,7 +43,7 @@ export default function FilterButton({
           </div>
           <span>
             {selectedDateOption
-              ? `${selectedDateOption.firstDate} - ${selectedDateOption.secondDate}`
+              ? `${selectedDateOption.firstDate} - ${selectedDateOption.secondDate || selectedDateOption.firstDate}`
               : "날짜 선택"}
           </span>
         </div>

--- a/src/components/Filter/FilterDropDown.tsx
+++ b/src/components/Filter/FilterDropDown.tsx
@@ -36,6 +36,7 @@ export function FilterDropDown({ filterType, options, onSelectFilterOption }: Fi
         selectedOption={selectedOption}
         filterType={filterType}
         onToggle={toggleDropdown}
+        isOpen={isOpen}
       />
 
       <Dropdown

--- a/src/components/Gnb.tsx
+++ b/src/components/Gnb.tsx
@@ -148,7 +148,11 @@ export default function Gnb() {
                   <Image
                     src={image || "/images/profile.svg"}
                     fill
-                    style={{ objectFit: "cover" }}
+                    style={{
+                      objectFit: "cover",
+                      objectPosition: "center",
+                    }}
+                    sizes="40px"
                     alt="프로필"
                   />
                 </button>

--- a/src/types/components/filter.d.ts
+++ b/src/types/components/filter.d.ts
@@ -1,6 +1,7 @@
-type FilterType = "sortFilter" | "selectionFilter";
+type FilterType = "sortFilter" | "selectionFilter" | "calendarFilter";
 
 type OptionType = { ko: string; eng: string };
+type CalendarType = { firstDate?: string; secondDate?: string };
 
 type FilterDropdownProps = {
   filterType: FilterType;
@@ -10,7 +11,7 @@ type FilterDropdownProps = {
 
 type FilterButtonProps = {
   selectedOption?: OptionType;
-  selectedDateOption?: string;
+  selectedDateOption?: CalendarType | null;
   filterType: string;
   onToggle: () => void;
 };

--- a/src/types/components/filter.d.ts
+++ b/src/types/components/filter.d.ts
@@ -14,6 +14,7 @@ type FilterButtonProps = {
   selectedDateOption?: CalendarType | null;
   filterType: string;
   onToggle: () => void;
+  isOpen: boolean;
 };
 
 type DropdownProps = {


### PR DESCRIPTION
## #️⃣연관된 이슈

> MNM-41

## 📝작업 내용

> - 상세페이지 웹접근성 개선 (ARIA 적용, tabIndex추가...)
> - 프리패칭된 데이터가 DOM에 렌더링되도록 API 요청 방식 수정
> - 코드 가독성 향상을 위한 코드 변경 
> - Map 컴포넌트 로딩 중 및 로딩 에러 발생 시에 따른 UI 추가
> - 필터버튼에 calendarFilter타입 추가, 
> - 캘린터 컴포넌트 리팩토링
>   - 필터버튼에 선택된 날짜표시
>   - 기간 선택시 사이날짜 회색배경으로 변경
>   - 오늘 날짜 이전 선택 안되게하고 텍스트 회색처리함
>   - 모바일환경시 캘린더를 화면 중앙으로 보이게 변경

### 스크린샷 (선택)
#### - 캘린더
![image](https://github.com/user-attachments/assets/d85ae6e3-170b-4f27-b02b-6a346b68aba1)

## 💬리뷰 요구사항(선택)

